### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/NEA-Final/RooksRealm/frontend/package.json
+++ b/NEA-Final/RooksRealm/frontend/package.json
@@ -19,7 +19,8 @@
     "jwt-decode": "^4.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.27.0"
+    "react-router-dom": "^6.27.0",
+    "dompurify": "^3.2.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.11.1",

--- a/NEA-Final/RooksRealm/frontend/src/components/account/Account.tsx
+++ b/NEA-Final/RooksRealm/frontend/src/components/account/Account.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useAuth } from "../../contexts/AuthProvider";
 import { useToast } from "@chakra-ui/react";
-
+import DOMPurify from 'dompurify';
 interface UserDetails {
   username: string;
   email: string;
@@ -107,7 +107,7 @@ const Account: React.FC = () => {
     setTheme(selectedTheme);
     const isValidTheme = await validateTheme(selectedTheme);
     if (isValidTheme) {
-      setThemePreview(`/images/boards/${selectedTheme}.png`);
+      setThemePreview(DOMPurify.sanitize(`/images/boards/${selectedTheme}.png`));
     } else {
       setThemePreview("");
     }


### PR DESCRIPTION
Fixes [https://github.com/MaximumFire/school-work/security/code-scanning/2](https://github.com/MaximumFire/school-work/security/code-scanning/2)

To fix the problem, we need to ensure that the `themePreview` variable is properly sanitized before being used as the `src` attribute of the `img` element. This can be done by using a library like `DOMPurify` to sanitize the URL or by ensuring that the `validateTheme` function is robust enough to prevent any malicious input.

The best way to fix the problem without changing existing functionality is to use `DOMPurify` to sanitize the `themePreview` URL before setting it. This ensures that any potentially malicious content is removed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
